### PR TITLE
Fix dependency warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     test_suite="tests",
     packages=['elma'],
     install_requires=[
-        'flake8==3.3.0',
-        'pillow==4.0.0',
+        'flake8>=3.3.0',
+        'pillow>=4.0.0',
     ],
 )


### PR DESCRIPTION
It's Hacktoberfest again, so I'm making some PRs. :)

The library dependencies have strict version requirements. This makes pip complain, if you are using newer versions of those dependencies.

This PR fixes those pip errors. I checked that the tests pass with `flake==3.7.8` and `Pillow==6.2.0`, which are the latest versions of the library dependencies at the moment.